### PR TITLE
Fix bit.ly url

### DIFF
--- a/ski_trip.rst
+++ b/ski_trip.rst
@@ -30,6 +30,6 @@ Fill out this `form <https://goo.gl/forms/VQ9idq4dvJFzpAM02>`_ to help organize
 group activities for either Whistler or Cypress Mountain.
 
 Join the #ski-trip channel on PyCascades’s Slack. You may self-join using this
-`link <http://bit.ly/pycascades-slack>`_.
+`link <http://bit.ly/pycascades-slack/>`_.
 
 Back to the :ref:`Welcome Wagon <index>`.

--- a/sprint.rst
+++ b/sprint.rst
@@ -25,7 +25,7 @@ Projects
 
 Propose a `pull request <https://github.com/pycascades/welcome-wagon-2018>`_ to
 add your project. You can also discuss sprint on our #sprint channel on
-`Slack <http://bit.ly/pycascades-slack>`_.
+`Slack <http://bit.ly/pycascades-slack/>`_.
 
 Example:
 


### PR DESCRIPTION
The trailing slash is important.
 Fixes #36 