### PR TITLE
Adding a new document for tracking the slide decks associated with each talk

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -52,7 +52,7 @@ Other resources
 
    ski_trip
    sprint
-   slides
+   talk_slides
 
 
 FAQs

--- a/index.rst
+++ b/index.rst
@@ -52,6 +52,7 @@ Other resources
 
    ski_trip
    sprint
+   slides
 
 
 FAQs

--- a/talk_slides.rst
+++ b/talk_slides.rst
@@ -28,7 +28,7 @@ From Tuesday
 - Kojo Idrissa: Python & Spreadsheets: Canadian Edition
 - Lukasz Langa: Gradual Typing of Production Applications
 - Rachael Tatman: `Character Encoding and You <https://docs.google.com/presentation/d/17xwPZrnGo5xGUXf_HkxFUTAE2SPisHQd7LcRWyYCL6I/edit#slide=id.p>`_
-- Yusuke Tsutsumi: Taming the Hydra: How we Learned to Love Testing a Giant Python Codebase
+- Yusuke Tsutsumi: `Taming the Hydra: How we Learned to Love Testing a Giant Python Codebase <https://docs.google.com/presentation/d/1nDIzNuuFXsLIRIT2xCJG55WSRKThY1jZlJg9mVv1hs0/edit?usp=sharing>`_
 - Karina Ruzinov: Shipping Secret Messages through Barcodes
 - Dhruv Govil: Python for Feature Film
 - Kenneth Love: Those Who Care, Teach!

--- a/talk_slides.rst
+++ b/talk_slides.rst
@@ -35,3 +35,6 @@ From Tuesday
 
 Lightning Talks
 ***************
+
+
+Back to the :ref:`Welcome Wagon <index>`.

--- a/talk_slides.rst
+++ b/talk_slides.rst
@@ -1,0 +1,37 @@
+.. _slides:
+
+Slides for PyCascades 2018
+==========================
+
+From Monday
+-----------
+
+- Guido Van Rossum: BDFL Python 3 Retrospective
+- Holly Becker: Can I Use That Code? Software Licenses as a User
+- Nicholas Hunt-Walker: `A Web App in Four Frameworks <https://docs.google.com/presentation/d/1LkAkmpUu_vqc1h8FxxKRyEH59A-8-7ss88-Z9Wkk_ms/edit#slide=id.p>`_
+- Emily Morehouse-Valcarcel: The AST and Me
+- Nick Denny: It's a Kind of Magic
+- Stephanie Kim: Racial Bias in Facial Recognition Software
+- Thomas Ballinger: Python is not Java or C++
+- Lindsey Dragun: Bad Accessibility Happens - That Doesn't Have to Be the End
+- Anna Liao: RaspberryPy to RustyPi: Porting a Python Module to Rust
+- Brett Cannon: Setting Expectations for Open Source Participation
+
+Lightning Talks
+***************
+
+From Tuesday
+------------
+
+- Anna Schneider: Navigating Unconscious Bias
+- Sev Leonard: Can you please pass the data? IoT Communication with MicroPython
+- Kojo Idrissa: Python & Spreadsheets: Canadian Edition
+- Lukasz Langa: Gradual Typing of Production Applications
+- Rachael Tatman: Character Encoding and You
+- Yusuke Tsutsumi: Taming the Hydra: How we Learned to Love Testing a Giant Python Codebase
+- Karina Ruzinov: Shipping Secret Messages through Barcodes
+- Dhruv Govil: Python for Feature Film
+- Kenneth Love: Those Who Care, Teach!
+
+Lightning Talks
+***************

--- a/talk_slides.rst
+++ b/talk_slides.rst
@@ -27,7 +27,7 @@ From Tuesday
 - Sev Leonard: Can you please pass the data? IoT Communication with MicroPython
 - Kojo Idrissa: Python & Spreadsheets: Canadian Edition
 - Lukasz Langa: Gradual Typing of Production Applications
-- Rachael Tatman: Character Encoding and You
+- Rachael Tatman: `Character Encoding and You <https://docs.google.com/presentation/d/17xwPZrnGo5xGUXf_HkxFUTAE2SPisHQd7LcRWyYCL6I/edit#slide=id.p>`_
 - Yusuke Tsutsumi: Taming the Hydra: How we Learned to Love Testing a Giant Python Codebase
 - Karina Ruzinov: Shipping Secret Messages through Barcodes
 - Dhruv Govil: Python for Feature Film


### PR DESCRIPTION
I've divided the document into the slides for Monday and Tuesday sessions. I also added space for lightning talks if there are slide decks that people want to have posted. Ideally, once we have the link to someone's slide deck we would update the document with their linked slides.